### PR TITLE
Pin dep versions to retain compatibility with ESLint 8, TSLint 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ rules that encourage consistency, safety and readability across your code base.
 
 Read [this](https://timjames.dev/blog/the-best-eslint-rules-for-react-projects-30i8) blog post describing my general approach.
 
-Note that ESLint is in the midst of a major upgrade to version 9, which brings with it significant changes to the configuration syntax. The AirBnB configuration - among other related tools - does not yet support v9. For now, all our documentation and approach refers to the 'legacy' ESLint syntax. Therefore, when using this config, make sure to stick with: 
+Note that ESLint is in the midst of a major upgrade to version 9, which brings with it significant changes to the configuration syntax. The AirBnB configuration - among other related tools - does not yet support v9. For now, all our documentation and approach refers to the 'legacy' ESLint syntax. Therefore, when using this config, make sure to stick with:
+
 * ESLint 8
-* TSESLint 7 (/parser and /eslint-plugin)
+* TSESLint 7 (install @typescript-eslint/parser and @typescript-eslint/eslint-plugin, per the guide on [Legacy ESLint Setup](https://typescript-eslint.io/getting-started/legacy-eslint-setup) )
 
 ## Install
 
@@ -17,7 +18,7 @@ Note that ESLint is in the midst of a major upgrade to version 9, which brings w
 npm install -D @tim-w-james/eslint-config \
   @typescript-eslint/eslint-plugin \
   @typescript-eslint/parser \
-  eslint \
+  eslint@8 \
   eslint-config-airbnb \
   eslint-config-airbnb-typescript \
   eslint-config-prettier \
@@ -46,7 +47,7 @@ npm install -D @tim-w-james/eslint-config \
 yarn add -D @tim-w-james/eslint-config \
   @typescript-eslint/eslint-plugin \
   @typescript-eslint/parser \
-  eslint \
+  eslint@8 \
   eslint-config-airbnb \
   eslint-config-airbnb-typescript \
   eslint-config-prettier \
@@ -75,7 +76,7 @@ yarn add -D @tim-w-james/eslint-config \
 pnpm add -D @tim-w-james/eslint-config \
   @typescript-eslint/eslint-plugin \
   @typescript-eslint/parser \
-  eslint \
+  eslint@8 \
   eslint-config-airbnb \
   eslint-config-airbnb-typescript \
   eslint-config-prettier \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ rules that encourage consistency, safety and readability across your code base.
 
 Read [this](https://timjames.dev/blog/the-best-eslint-rules-for-react-projects-30i8) blog post describing my general approach.
 
+Note that ESLint is in the midst of a major upgrade to version 9, which brings with it significant changes to the configuration syntax. The AirBnB configuration - among other related tools - does not yet support v9. For now, all our documentation and approach refers to the 'legacy' ESLint syntax. Therefore, when using this config, make sure to stick with: 
+* ESLint 8
+* TSESLint 7 (/parser and /eslint-plugin)
+
 ## Install
 
 ### `npm`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Read [this](https://timjames.dev/blog/the-best-eslint-rules-for-react-projects-3
 ### `npm`
 
 ```sh
-npm install --dev @tim-w-james/eslint-config \
+npm install -D @tim-w-james/eslint-config \
   @typescript-eslint/eslint-plugin \
   @typescript-eslint/parser \
   eslint \

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
-    "eslint": ">=8.0.0",
+    "eslint": "^8.0.0",
     "eslint-config-airbnb": ">=19.0.0",
     "eslint-config-airbnb-typescript": ">=17.0.0",
     "eslint-config-prettier": ">=8.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.56.0",
-    "@typescript-eslint/parser": "^5.56.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.51.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",
@@ -51,8 +51,8 @@
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">=4.0.0",
-    "@typescript-eslint/parser": ">=4.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "eslint": ">=8.0.0",
     "eslint-config-airbnb": ">=19.0.0",
     "eslint-config-airbnb-typescript": ">=17.0.0",


### PR DESCRIPTION
Hi, and thanks for this great, opinionated config. It should be adopted en masse! 

While installing and configuring, I ran into some problems because of the new version of ESLint, which changes A LOT. Similarly ESTSLint also has a new, matching version.

But, AirBnB hasn't yet updated their configs to be compatible. (See: [Issue](https://github.com/airbnb/javascript/issues/2961)) So, that means users of this config will need to consciously stick with ESLint v8 and ESTSLint v7 for now, at least until AirBnB finishes adding support.

So, I propose these related changes (each is a separate commit): 
* The ESLint changes aren't mentioned in the README and will no doubt confuse some users, so I've added some lines clarifying
* Further, we can solve the peer-deps conflict by just pinning ESTSLint to v7. 
* And, there's just a glitch seemingly caused by a copy-paste in the example 'npm install' command, which I fixed